### PR TITLE
Refactor: Improve mcp-thisweek usability, add Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,10 +20,21 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
-
-# Virtual Environment
 venv/
 ENV/
+pip-log.txt
+pip-delete-this-directory.txt
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.log
+*.pot
+*.mo
 
 # IDE
 .idea/
@@ -35,5 +46,8 @@ ENV/
 .DS_Store
 Thumbs.db
 
-# program
+# Program specific
 debug.log
+
+# Docker
+Dockerfile.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 # Set the working directory in the container
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container at /app
+COPY requirements.txt .
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code into the container at /app
+COPY . .
+
+# Make port 8080 available to the world outside this container (if server uses a port)
+# FastMCP typically doesn't run as a traditional web server on a specific port by default when used with `fastmcp run`.
+# However, if direct execution implies it might listen on a port or if it's intended for future use, uncomment and adjust.
+# EXPOSE 8080
+
+# Define environment variables if necessary
+# ENV NAME World
+
+# Run server.py when the container launches
+CMD ["python", "server.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ COPY . .
 # ENV NAME World
 
 # Run server.py when the container launches
-CMD ["python", "server.py"]
+CMD ["tail", "-f", "/dev/null"]

--- a/README.ja.md
+++ b/README.ja.md
@@ -32,14 +32,15 @@ pipとPythonを使用するか、Dockerを使用して`mcp-thisweek`をセット
 3.  **MCPクライアントを設定します:**
     `mcp-thisweek`をMCPクライアントの設定ファイル（例:`mcp.json`または`claude_desktop_config.json`）に追加します。
 
-    `/path/to/`をシステムの`mcp-thisweek`ディレクトリへの実際のパスに置き換えてください。また、`python`がシステムのPATHにない場合は、`/path/to/python`のように置き換える必要があるかもしれません。
+    `command`の`/path/to/fastmcp`を使用する`fastmcp`のパスに、`args`の`/path/to/mcp-thisweek/server.py`を`mcp-thisweek`ディレクトリにある`server.py`スクリプトへの実際のパスに置き換えてください。
 
     ```json
     {
       "mcpServers": {
         "mcp-thisweek": {
-          "command": "python",
+          "command": "/path/to/fastmcp",
           "args": [
+            "run",
             "/path/to/mcp-thisweek/server.py"
           ]
         }

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,92 @@
+# mcp-thisweek
+
+今週の月曜日から金曜日までの日付と今日の日付を提供するシンプルなMCP（Model Context Protocol）サーバーです。
+
+## 機能
+
+-   `get_this_week_dates`: 今週の月曜日から金曜日までの日付のリストを返します。
+-   `get_today_date`: 今日の日付を返します。
+
+### 例
+
+-   "今週の月曜日から金曜日までの日付を教えてください"
+-   "今日は何日ですか"
+
+## セットアップ
+
+pipとPythonを使用するか、Dockerを使用して`mcp-thisweek`をセットアップして実行できます。
+
+### pipとPythonを使用する
+
+1.  **リポジトリをクローンします:**
+    ```bash
+    git clone https://github.com/taku-o/mcp-thisweek.git
+    cd mcp-thisweek
+    ```
+
+2.  **依存関係をインストールします:**
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+3.  **MCPクライアントを設定します:**
+    `mcp-thisweek`をMCPクライアントの設定ファイル（例:`mcp.json`または`claude_desktop_config.json`）に追加します。
+
+    `/path/to/`をシステムの`mcp-thisweek`ディレクトリへの実際のパスに置き換えてください。また、`python`がシステムのPATHにない場合は、`/path/to/python`のように置き換える必要があるかもしれません。
+
+    ```json
+    {
+      "mcpServers": {
+        "mcp-thisweek": {
+          "command": "python",
+          "args": [
+            "/path/to/mcp-thisweek/server.py"
+          ]
+        }
+      }
+    }
+    ```
+
+### Dockerを使用する
+
+1.  **Dockerイメージをビルドします:**
+    プロジェクトのルートディレクトリ（`Dockerfile`がある場所）に移動し、以下を実行します:
+    ```bash
+    docker build -t mcp-thisweek .
+    ```
+
+2.  **Dockerコンテナを実行します:**
+    ```bash
+    docker run -d --name mcp-thisweek-container mcp-thisweek
+    ```
+    これにより、コンテナがデタッチモードで実行されます。
+
+3.  **MCPクライアントを設定します（Docker用）:**
+    Dockerを使用する場合、`fastmcp`はコンテナ内で実行されているサーバーと通信する必要があります。`fastmcp`は通常、ローカルコマンド実行を使用します。これをDockerで機能させるには、ラッパースクリプトが必要になるか、`fastmcp`がコンテナに`docker exec`する必要がある場合や、`fastmcp`自体がDockerネットワーク内で実行される場合に、`fastmcp`がサーバーを呼び出す方法を調整する必要がある場合があります。
+
+    `fastmcp`が使用される一般的な方法は、`fastmcp`が実行できるコマンドを指定することです。`fastmcp`がホスト上で実行されている場合、`docker exec`なしではDockerコンテナ内のPythonスクリプトを直接実行できません。
+
+    Docker化された`mcp-server`の場合、`mcp.json`の`command`は通常`docker exec -i mcp-thisweek-container python /app/server.py`のようになります。これは、`fastmcp`がホスト上で実行されており、コンテナ名が`mcp-thisweek-container`であることを前提としています。
+
+    Docker用のJSON設定は次のようになります:
+    ```json
+    {
+      "mcpServers": {
+        "mcp-thisweek": {
+          "command": "docker",
+          "args": [
+            "exec",
+            "-i",
+            "mcp-thisweek-container",
+            "python",
+            "/app/server.py"
+          ]
+        }
+      }
+    }
+    ```
+    コンテナ`mcp-thisweek-container`が実行されていることを確認してください。
+
+## ライセンス
+
+このプロジェクトはMITライセンスの下でライセンスされています。

--- a/README.ja.md
+++ b/README.ja.md
@@ -32,15 +32,14 @@ pipとPythonを使用するか、Dockerを使用して`mcp-thisweek`をセット
 3.  **MCPクライアントを設定します:**
     `mcp-thisweek`をMCPクライアントの設定ファイル（例:`mcp.json`または`claude_desktop_config.json`）に追加します。
 
-    `command`の`/path/to/fastmcp`を使用する`fastmcp`のパスに、`args`の`/path/to/mcp-thisweek/server.py`を`mcp-thisweek`ディレクトリにある`server.py`スクリプトへの実際のパスに置き換えてください。
+    `args`の`/path/to/mcp-thisweek/server.py`を`mcp-thisweek`ディレクトリにある`server.py`スクリプトへの実際のパスに置き換えてください。また、`command`の`python`は、Python 3.10+インタプリタがシステムのPATHにない場合、フルパスに置き換える必要があるかもしれません。
 
     ```json
     {
       "mcpServers": {
         "mcp-thisweek": {
-          "command": "/path/to/fastmcp",
+          "command": "python",
           "args": [
-            "run",
             "/path/to/mcp-thisweek/server.py"
           ]
         }
@@ -58,7 +57,7 @@ pipとPythonを使用するか、Dockerを使用して`mcp-thisweek`をセット
 
 2.  **Dockerコンテナを実行します:**
     ```bash
-    docker run -d --name mcp-thisweek-container mcp-thisweek
+    docker run -d --rm --name mcp-thisweek-container mcp-thisweek
     ```
     これにより、コンテナがデタッチモードで実行されます。
 

--- a/README.md
+++ b/README.md
@@ -1,49 +1,92 @@
 # mcp-thisweek
 
-今週の月曜日から金曜日の日付と、今日の日付を返すシンプルなMCP(Model Context Protocol)です。
+A simple MCP (Model Context Protocol) server that provides the dates for the current week (Monday to Friday) and today's date.
 
-## 機能
+## Features
 
-- 今週の日付（月曜日から金曜日）の取得 get_this_week_dates
-- 今日の日付の取得 get_today_date
+-   `get_this_week_dates`: Returns a list of dates from Monday to Friday of the current week.
+-   `get_today_date`: Returns today's date.
 
-### 例
+### Examples
 
-- 今週の月曜日から金曜日までの日付を教えてください。
-- 今日の日付を教えてください。
+-   "What are the dates for this week from Monday to Friday?"
+-   "What is today's date?"
 
-## セットアップ
+## Setup
 
-### download and setup mcp-thisweek
-```
-# download mcp-thisweek
-git clone git@github.com:taku-o/mcp-thisweek.git
+You can set up and run `mcp-thisweek` using pip and Python, or using Docker.
 
-cd mcp-thisweek
-pip install -r requirements.txt
+### Using pip and Python
 
-# get fastmcp path
-which fastmcp
-```
+1.  **Clone the repository:**
+    ```bash
+    git clone https://github.com/taku-o/mcp-thisweek.git
+    cd mcp-thisweek
+    ```
 
-### add mcp-thisweek MCP server to mcp.json, or claude_desktop_config.json
+2.  **Install dependencies:**
+    ```bash
+    pip install -r requirements.txt
+    ```
 
-- replace "/path/to" with your path on example.
+3.  **Configure your MCP client:**
+    Add `mcp-thisweek` to your MCP client's configuration file (e.g., `mcp.json` or `claude_desktop_config.json`).
 
-```
-{
-  "mcpServers": {
-    "mcp-thisweek": {
-      "command": "/path/to/fastmcp",
-      "args": [
-        "run",
-        "/path/to/mcp-thisweek/server.py"
-      ]
+    Replace `/path/to/` with the actual path to the `mcp-thisweek` directory on your system. You may also need to replace `python` with `/path/to/python` if it's not in your system's PATH.
+
+    ```json
+    {
+      "mcpServers": {
+        "mcp-thisweek": {
+          "command": "python",
+          "args": [
+            "/path/to/mcp-thisweek/server.py"
+          ]
+        }
+      }
     }
-  }
-}
-```
+    ```
 
-## ライセンス
+### Using Docker
 
-MIT
+1.  **Build the Docker image:**
+    Navigate to the root directory of the project (where the `Dockerfile` is located) and run:
+    ```bash
+    docker build -t mcp-thisweek .
+    ```
+
+2.  **Run the Docker container:**
+    ```bash
+    docker run -d --name mcp-thisweek-container mcp-thisweek
+    ```
+    This will run the container in detached mode.
+
+3.  **Configure your MCP client (for Docker):**
+    When using Docker, `fastmcp` needs to communicate with the server running inside the container. `FastMCP` typically uses local command execution. To make this work with Docker, you might need a wrapper script or adjust how `fastmcp` invokes the server if it needs to `docker exec` into the container or if `fastmcp` itself is run inside a Docker network.
+
+    A common way `fastmcp` is used is by specifying a command that `fastmcp` can run. If `fastmcp` is running on the host, it cannot directly execute a Python script inside a Docker container without `docker exec`.
+
+    For a Dockerized `mcp-server`, the `command` in `mcp.json` would typically be `docker exec -i mcp-thisweek-container python /app/server.py`. This assumes `fastmcp` is running on the host and the container is named `mcp-thisweek-container`.
+
+    The JSON configuration for Docker would look like:
+    ```json
+    {
+      "mcpServers": {
+        "mcp-thisweek": {
+          "command": "docker",
+          "args": [
+            "exec",
+            "-i",
+            "mcp-thisweek-container",
+            "python",
+            "/app/server.py"
+          ]
+        }
+      }
+    }
+    ```
+    Ensure the container `mcp-thisweek-container` is running.
+
+## License
+
+This project is licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -32,14 +32,15 @@ You can set up and run `mcp-thisweek` using pip and Python, or using Docker.
 3.  **Configure your MCP client:**
     Add `mcp-thisweek` to your MCP client's configuration file (e.g., `mcp.json` or `claude_desktop_config.json`).
 
-    Replace `/path/to/` with the actual path to the `mcp-thisweek` directory on your system. You may also need to replace `python` with `/path/to/python` if it's not in your system's PATH.
+    Replace `/path/to/fastmcp` with the path to your `fastmcp` executable and `/path/to/mcp-thisweek/server.py` with the path to the `server.py` script in the `mcp-thisweek` directory.
 
     ```json
     {
       "mcpServers": {
         "mcp-thisweek": {
-          "command": "python",
+          "command": "/path/to/fastmcp",
           "args": [
+            "run",
             "/path/to/mcp-thisweek/server.py"
           ]
         }

--- a/README.md
+++ b/README.md
@@ -32,15 +32,14 @@ You can set up and run `mcp-thisweek` using pip and Python, or using Docker.
 3.  **Configure your MCP client:**
     Add `mcp-thisweek` to your MCP client's configuration file (e.g., `mcp.json` or `claude_desktop_config.json`).
 
-    Replace `/path/to/fastmcp` with the path to your `fastmcp` executable and `/path/to/mcp-thisweek/server.py` with the path to the `server.py` script in the `mcp-thisweek` directory.
+    Replace `/path/to/mcp-thisweek/server.py` with the actual path to the `server.py` script in the `mcp-thisweek` directory. You may also need to replace `python` with the full path to your Python 3.10+ interpreter if it's not in your system's PATH.
 
     ```json
     {
       "mcpServers": {
         "mcp-thisweek": {
-          "command": "/path/to/fastmcp",
+          "command": "python",
           "args": [
-            "run",
             "/path/to/mcp-thisweek/server.py"
           ]
         }
@@ -58,7 +57,7 @@ You can set up and run `mcp-thisweek` using pip and Python, or using Docker.
 
 2.  **Run the Docker container:**
     ```bash
-    docker run -d --name mcp-thisweek-container mcp-thisweek
+    docker run -d --rm --name mcp-thisweek-container mcp-thisweek
     ```
     This will run the container in detached mode.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-thisweek"
-version = "0.1.0"
+version = "0.1.1"
 description = "A simple MCP (Model Context Protocol) that returns the dates from Monday to Friday of this week, and today's date."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.py
+++ b/server.py
@@ -7,7 +7,7 @@ from fastmcp import FastMCP
 
 # ロガーの設定
 logging.basicConfig(
-    # filename='debug.log',  # Log to a local file, commented out
+    #filename='debug.log',  # Log to a local file, commented out
     #level=logging.DEBUG,
     level=logging.CRITICAL + 1,  # Disable logging by setting level above CRITICAL
     format='%(asctime)s - %(levelname)s - %(message)s'

--- a/server.py
+++ b/server.py
@@ -7,7 +7,7 @@ from fastmcp import FastMCP
 
 # ロガーの設定
 logging.basicConfig(
-    filename='debug.log',  # Log to a local file
+    # filename='debug.log',  # Log to a local file, commented out
     #level=logging.DEBUG,
     level=logging.CRITICAL + 1,  # Disable logging by setting level above CRITICAL
     format='%(asctime)s - %(levelname)s - %(message)s'

--- a/server.py
+++ b/server.py
@@ -7,9 +7,9 @@ from fastmcp import FastMCP
 
 # ロガーの設定
 logging.basicConfig(
-    filename='/Users/taku.omi/Documents/workspaces/mcp-thisweek/debug.log',
+    filename='debug.log',  # Log to a local file
     #level=logging.DEBUG,
-    level=logging.CRITICAL + 1,  # CRITICALより上のレベルを設定することでログ出力を無効化
+    level=logging.CRITICAL + 1,  # Disable logging by setting level above CRITICAL
     format='%(asctime)s - %(levelname)s - %(message)s'
 )
 
@@ -44,3 +44,9 @@ def get_today_date() -> str:
     result = today.strftime("%m/%d")
     logging.debug(f"今日の日付: {result}")
     return result
+
+if __name__ == "__main__":
+    # Start the server
+    # The following line assumes `mcp` is the FastMCP instance.
+    # Adjust if your server instance has a different name or needs specific startup arguments.
+    mcp.run()


### PR DESCRIPTION
This pull request introduces a comprehensive refactoring of the `mcp-thisweek` project to improve its usability, maintainability, and deployment options.

**Key Changes:**

*   **English README:** Added a new `README.md` in English and renamed the original Japanese README to `README.ja.md`. Both READMEs now include updated setup instructions.
*   **Simplified Pip/Python Usage:**
    *   `server.py` is now directly executable (e.g., `python server.py`), simplifying the setup for MCP clients.
    *   The recommended pip/Python setup in the READMEs now reflects this direct execution method.
    *   Ensured compatibility with `fastmcp run server.py` for users who prefer that invocation.
*   **Docker Support:**
    *   Added a `Dockerfile` to allow users to easily build and run `mcp-thisweek` as a Docker container.
    *   The container is configured to stay running in the background (`tail -f /dev/null`) and `server.py` is invoked via `docker exec`, as detailed in the READMEs.
    *   The `docker run` command in the READMEs now includes the `--rm` option for automatic container cleanup.
*   **Logging Improvements:**
    *   Modified `server.py` to default logging to `stderr` by commenting out the `filename` parameter in `logging.basicConfig`. This resolves path-related issues encountered with file-based logging in different execution environments.
*   **`.gitignore` Update:** Added common Python and Docker artifacts to the `.gitignore` file.
*   **Iterative Fixes:**
    *   Addressed issues with Python version compatibility for `fastmcp` in the Dockerfile by upgrading the base Python image.
    *   Resolved problems with the Docker container stopping prematurely by changing the `CMD` instruction.
    *   Worked through several iterations to ensure consistent behavior for both direct Python execution and `fastmcp run` methods.

These changes make `mcp-thisweek` more accessible, easier to set up for different user preferences, and provide robust deployment options via Docker. All functionalities (direct Python execution, `fastmcp run`, and Docker) have been confirmed to be working.