### PR TITLE
Use System Timezone Instead of Hardcoded Asia/Tokyo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-thisweek"
-version = "0.1.1"
+version = "0.1.2"
 description = "A simple MCP (Model Context Protocol) that returns the dates from Monday to Friday of this week, and today's date."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-dateutil>=2.8.2
 pytz>=2024.1
 fastmcp>=0.4.1
+tzlocal

--- a/server.py
+++ b/server.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 import pytz
 from dateutil.relativedelta import relativedelta, MO
 from fastmcp import FastMCP
+from tzlocal import get_localzone
 
 # ロガーの設定
 logging.basicConfig(
@@ -20,8 +21,8 @@ mcp = FastMCP("mcp-thisweek")
 def get_this_week_dates() -> list[str]:
     """今週の月曜日から金曜日までの日付を返す"""
     logging.debug("get_this_week_dates が呼び出されました")
-    jst = pytz.timezone('Asia/Tokyo')
-    today = datetime.now(jst)
+    local_tz = get_localzone()
+    today = datetime.now(local_tz)
     
     # 今週の月曜日を取得
     monday = today + relativedelta(weekday=MO(-1))
@@ -39,8 +40,8 @@ def get_this_week_dates() -> list[str]:
 def get_today_date() -> str:
     """今日の日付を返す"""
     logging.debug("get_today_date が呼び出されました")
-    jst = pytz.timezone('Asia/Tokyo')
-    today = datetime.now(jst)
+    local_tz = get_localzone()
+    today = datetime.now(local_tz)
     result = today.strftime("%m/%d")
     logging.debug(f"今日の日付: {result}")
     return result

--- a/test_timezone.py
+++ b/test_timezone.py
@@ -1,0 +1,23 @@
+from server import get_today_date
+from datetime import datetime
+import pytz # Make sure pytz is available for the test script
+import os
+
+# Get the timezone from the TZ environment variable, default to UTC if not set
+tz_name = os.environ.get('TZ', 'UTC')
+try:
+    expected_tz = pytz.timezone(tz_name)
+except pytz.exceptions.UnknownTimeZoneError:
+    print(f"Error: Unknown timezone specified in TZ environment variable: {tz_name}")
+    exit(1)
+
+expected_date = datetime.now(expected_tz).strftime("%m/%d")
+actual_date = get_today_date() # This should now use the TZ environment variable
+
+print(f"TZ={tz_name}, Expected={expected_date}, Actual={actual_date}")
+
+if expected_date == actual_date:
+    print("Test PASSED")
+else:
+    print("Test FAILED")
+    exit(1) # Exit with error code if test fails


### PR DESCRIPTION
The application's timezone handling has been updated to use the OS/system's local timezone. This was achieved by:

- Replacing the hardcoded 'Asia/Tokyo' timezone in `server.py` with a call to `get_localzone()` from the `tzlocal` library.
- Adding `tzlocal` to the `requirements.txt` file.
- Correcting the import for `get_localzone` to be `from tzlocal import get_localzone`.

I conducted tests by setting the TZ environment variable to different timezones (UTC, America/New_York, Asia/Tokyo), and the application correctly reflected the date in each respective timezone.

This change allows the application to adapt to the timezone of the environment it's running in, which is particularly useful for Docker deployments where the timezone can be configured via the `TZ` environment variable.