### PR TITLE
Switch to Docker Compose for container management

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -49,17 +49,16 @@ pipとPythonを使用するか、Dockerを使用して`mcp-thisweek`をセット
 
 ### Dockerを使用する
 
-1.  **Dockerイメージをビルドします:**
-    プロジェクトのルートディレクトリ（`Dockerfile`がある場所）に移動し、以下を実行します:
-    ```bash
-    docker build -t mcp-thisweek .
-    ```
+プロジェクトのルートディレクトリ（`Dockerfile`と`docker-compose.yml`がある場所）に移動し、以下を実行します:
+```bash
+docker-compose up -d --build
+```
+これにより、イメージが存在しない場合はビルドされ、コンテナがデタッチモードで起動します。
 
-2.  **Dockerコンテナを実行します:**
-    ```bash
-    docker run -d --rm --name mcp-thisweek-container mcp-thisweek
-    ```
-    これにより、コンテナがデタッチモードで実行されます。
+コンテナを停止および削除するには、次のコマンドを実行します。
+```bash
+docker-compose down
+```
 
 3.  **MCPクライアントを設定します（Docker用）:**
     Dockerを使用する場合、`fastmcp`はコンテナ内で実行されているサーバーと通信する必要があります。`fastmcp`は通常、ローカルコマンド実行を使用します。これをDockerで機能させるには、ラッパースクリプトが必要になるか、`fastmcp`がコンテナに`docker exec`する必要がある場合や、`fastmcp`自体がDockerネットワーク内で実行される場合に、`fastmcp`がサーバーを呼び出す方法を調整する必要がある場合があります。

--- a/README.md
+++ b/README.md
@@ -49,17 +49,16 @@ You can set up and run `mcp-thisweek` using pip and Python, or using Docker.
 
 ### Using Docker
 
-1.  **Build the Docker image:**
-    Navigate to the root directory of the project (where the `Dockerfile` is located) and run:
-    ```bash
-    docker build -t mcp-thisweek .
-    ```
+Navigate to the root directory of the project (where the `Dockerfile` and `docker-compose.yml` are located) and run:
+```bash
+docker-compose up -d --build
+```
+This will build the image if it doesn't exist and start the container in detached mode.
 
-2.  **Run the Docker container:**
-    ```bash
-    docker run -d --rm --name mcp-thisweek-container mcp-thisweek
-    ```
-    This will run the container in detached mode.
+To stop and remove the container, run:
+```bash
+docker-compose down
+```
 
 3.  **Configure your MCP client (for Docker):**
     When using Docker, `fastmcp` needs to communicate with the server running inside the container. `FastMCP` typically uses local command execution. To make this work with Docker, you might need a wrapper script or adjust how `fastmcp` invokes the server if it needs to `docker exec` into the container or if `fastmcp` itself is run inside a Docker network.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+services:
+  mcp-thisweek:
+    build: .
+    image: mcp-thisweek
+    container_name: mcp-thisweek-container
+    restart: unless-stopped


### PR DESCRIPTION
This commit introduces Docker Compose to manage the mcp-thisweek container, replacing the previous docker run commands.

Key changes:
- Added a `docker-compose.yml` file defining the `mcp-thisweek` service with the `unless-stopped` restart policy and `mcp-thisweek-container` as the container name.
- Updated `README.md` and `README.ja.md` to reflect the new Docker Compose workflow, including commands for starting (`docker-compose up -d --build`) and stopping (`docker-compose down`) the container.
- Ensured the MCP client configuration examples in the README files remain accurate as the container name is unchanged.

This change simplifies the container startup and management process.